### PR TITLE
add swizzle method to fix setImage: bug

### DIFF
--- a/UIKit+AFNetworking/UIImageView+AFNetworking.m
+++ b/UIKit+AFNetworking/UIImageView+AFNetworking.m
@@ -57,6 +57,27 @@
     objc_setAssociatedObject(self, @selector(af_imageRequestOperation), imageRequestOperation, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }
 
++ (void)load{
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        Class clazz = self.class;
+        Method origMethod = class_getInstanceMethod(clazz, @selector(setImage:));
+        Method newMethod = class_getInstanceMethod(clazz, @selector(_setImage:));
+        if (origMethod && newMethod) {
+            method_exchangeImplementations(origMethod, newMethod);
+        }
+    });
+}
+
+- (void)_setImage:(UIImage *)image{
+    if ([self respondsToSelector:@selector(af_imageRequestOperation)]) {
+        if (self.af_imageRequestOperation && ![self.af_imageRequestOperation isFinished]) {
+            [self cancelImageRequestOperation];
+        }
+    }
+    [self _setImage:image];
+}
+
 @end
 
 #pragma mark -


### PR DESCRIPTION
When I use the UIImageView + AFNetworking, if my UIImageView not only needs to asynchronously access image by using UIImageView + AFNetworking, and it also should use setImage to set the local image. Because UIImageView + AFNetworking apply cancelImageRequestOperation to cancel the previous operation, however there is not have operation in the setImage.If the image is set frequently thus it may have problems on the display and it partly due to the cause of asynchronization.